### PR TITLE
substitute call to template.blockParams with 1.13 API hasBlockParams

### DIFF
--- a/addon/components/sift-and-list.js
+++ b/addon/components/sift-and-list.js
@@ -23,7 +23,7 @@ export default Ember.Component.extend({
     return this.get('_fields').map(f => {
       return {
         field: f,
-        direction: 'asc',
+        direction: 'asc'
       };
     });
   }.property('_fields'),

--- a/addon/templates/components/sift-and-list.hbs
+++ b/addon/templates/components/sift-and-list.hbs
@@ -1,6 +1,6 @@
 {{#each item in results}}
   {{! the component is being used in the block form, so we yield}}
-  {{#if template.blockParams}}
+  {{#if hasBlockParams}}
     {{yield item}}
   {{! no block so just display the item}}
   {{else}}

--- a/tests/unit/components/sift-and-list-test.js
+++ b/tests/unit/components/sift-and-list-test.js
@@ -12,7 +12,12 @@ test('it renders', function(assert) {
   assert.expect(2);
 
   // creates the component instance
-  var component = this.subject();
+  var component = this.subject({
+    sortBy: 'officerFullName',
+    list: [],
+    searchInput: '',
+    results: []
+  });
   assert.equal(component._state, 'preRender');
 
   // renders the component to the page


### PR DESCRIPTION
This PR fixes the component to work on Ember 1.13+
